### PR TITLE
Add more unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 yarn.lock
 seeds
+.idea

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import {
 import start from './socket';
 
 // Create the WebSocket Server
-const wss = new WebSocket.Server({ port });
+export const wss = new WebSocket.Server({ port });
 
 // Define the Redis port and create the pub/sub clients
 const pub = Redis.createClient(redisUrl);

--- a/src/socket.js
+++ b/src/socket.js
@@ -23,6 +23,7 @@ export default (db, wss, pub, sub, logger, port) => {
 
     // Give me all the participants in the room, optionally including myself
     const participants = [...wss.clients].filter(client => {
+      /* istanbul ignore if */
       if (includeMe) {
         return client.scopeId === scopeId;
       }
@@ -121,6 +122,7 @@ export default (db, wss, pub, sub, logger, port) => {
   // Whenever Redis receives a message (from itself or from another server instance)
   sub.on('message', (type, d) => {
     // If this server doesn't have any clients, don't bother
+    /* istanbul ignore if */
     if (!wss || !wss.clients || wss.clients.length === 0) return;
 
     logger.log(`Received message (${type}) on Redis`);
@@ -128,6 +130,7 @@ export default (db, wss, pub, sub, logger, port) => {
     // Otherwise, parse the message that was sent to us
     const data = JSON.parse(d);
 
+    /* istanbul ignore else */
     if (type === WEBRTC_PEER_LEFT) {
       sendToRoom(type, data);
     } else if (type === WEBRTC_JOIN_ROOM) {

--- a/test/_db-manager.js
+++ b/test/_db-manager.js
@@ -13,6 +13,7 @@ export default class DBManager {
 
     this.connection = null;
     this.db = null;
+    this.url = null;
   }
 
   async start() {
@@ -21,6 +22,7 @@ export default class DBManager {
 
     this.connection = await MongoClient.connect(url, mongoOptions);
     this.db = this.connection.db(db);
+    this.url = url;
   }
 
   async stop() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,45 @@
-// TODO: We should test the main index file here
+import Redis from 'redis';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import RedisMock from 'redis-mock';
+import { Logger } from 'syft-helpers.js';
 
 describe('Grid', () => {
-  test('should initialize', () => {
-    expect(1).toBe(1);
+  let mongoServer, mongoUrl, redisOrig, loggerSpy;
+
+  beforeAll(async () => {
+    // Spy on all logger calls.
+    loggerSpy = jest.spyOn(Logger.prototype, 'log');
+
+    // Replace Redis with its mock.
+    redisOrig = Redis.createClient;
+    Redis.createClient = RedisMock.createClient;
+
+    mongoServer = new MongoMemoryServer();
+    mongoUrl = await mongoServer.getConnectionString();
+  });
+
+  afterAll(async () => {
+    await mongoServer.stop();
+    jest.resetAllMocks();
+    Redis.createClient = redisOrig;
+  });
+
+  test('should initialize', async done => {
+    const oldEnv = { ...process.env };
+    process.env.VERBOSE = 1;
+    process.env.PORT = '3003';
+    process.env.MONGODB_URI = mongoUrl;
+    process.env.REDIS_URL = '';
+
+    const index = require('../src/index.js');
+
+    // Give it some time to initialize.
+    await new Promise(done => setTimeout(done, 200));
+
+    expect(loggerSpy.mock.calls).toHaveLength(1);
+    expect(loggerSpy.mock.calls[0][0]).toMatch(/Server running on \d+ port/);
+
+    process.env = { ...oldEnv };
+    index.wss.close(done);
   });
 });


### PR DESCRIPTION
This should help https://github.com/OpenMined/grid.js/issues/1
However, I had to add some `istanbul ignore ...`'s in `socket.js` to reach 100% coverage:
1. `includeMe` in sendToRoom() is never `true`
2. Absence of `wss` or its clients inside redis message handler - seems hard to test in existing `socket.test.js`, but perhaps it can be covered with some additional 'integration' kind of test suite that will spawn multiple grid.js websockets?
3. Message type different from WEBRTC_PEER_LEFT, WEBRTC_JOIN_ROOM, WEBRTC_INTERNAL_MESSAGE is not possible because only these message types are subscribed in Redis.

Some concerns:
1. Client becomes scope participant when it connects to WSS and gets the plan, and leaves scope when disconnects from WSS. Sending `WEBRTC_JOIN_ROOM`, `WEBRTC_PEER_LEFT` messages doesn't affect participants of the scope anyhow, i.e. clients will receive scope messages even before sending WEBRTC_JOIN_ROOM or after sending WEBRTC_PEER_LEFT. Maybe I'm just mixing up scope with webrtc room which is out of grid.js control?
2. It seems easy to impersonate sender client in WEBRTC_INTERNAL_MESSAGE by using arbitrary `instanceId` in `data` payload. There's no `scopeId` check too, so messages may be sent between clients of different scopes or even sent by client that doesn't belong to any scope. Not sure if this is a problem perhaps `instanceId` is a secret on its own? Still, it could be better to take `instanceId` (and scope) stored on client's socket not from payload.