### PR TITLE
Add protobuf data examples and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,12 +2245,12 @@
       }
     },
     "@openmined/syft.js": {
-      "version": "https://registry.npmjs.org/@vova/syft.js/-/syft.js-0.0.1-pb.tgz",
-      "integrity": "sha512-LgAVGU9qd7VWse7Pk7tawTJMEf5xO6njmvkNbBad6+WNhVGBlMY7Zml361An/V115O4GolN3V+4sxgvr+q3WnA==",
+      "version": "git+https://github.com/OpenMined/syft.js.git#e4dd30ab88bb8446b0f0991200483f8c98a505b3",
+      "from": "git+https://github.com/OpenMined/syft.js.git#vvm/git-installable",
       "requires": {
         "@tensorflow/tfjs": "^1.5.1",
         "long": "^4.0.0",
-        "syft-proto": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
+        "syft-proto": "git+https://github.com/OpenMined/syft-proto.git",
         "tuple-w": "^1.1.1"
       }
     },
@@ -2429,9 +2429,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
+      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
     },
     "@types/node-fetch": {
       "version": "2.5.4",
@@ -2759,125 +2759,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-          "dev": true
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -2891,15 +2772,6 @@
         "babel-preset-jest": "^24.9.0",
         "chalk": "^2.4.2",
         "slash": "^2.0.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -2941,126 +2813,6 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
       }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        }
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -3982,15 +3734,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "^2.0.0"
-      }
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -5338,15 +5081,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5394,16 +5128,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -5759,15 +5483,6 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -8446,15 +8161,6 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
-    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -9176,8 +8882,8 @@
       }
     },
     "syft-proto": {
-      "version": "git+https://github.com/OpenMined/syft-proto.git#0cae6d31b5277205a821a26e2492d632aeb0d311",
-      "from": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
+      "version": "git+https://github.com/OpenMined/syft-proto.git#b78d9a7ae91cb040b7aaacaf0a0b73589e1f37a1",
+      "from": "git+https://github.com/OpenMined/syft-proto.git",
       "requires": {
         "protobufjs": "~6.8.8"
       }
@@ -9393,12 +9099,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,8 +2245,8 @@
       }
     },
     "@openmined/syft.js": {
-      "version": "git+https://github.com/OpenMined/syft.js.git#e4dd30ab88bb8446b0f0991200483f8c98a505b3",
-      "from": "git+https://github.com/OpenMined/syft.js.git#vvm/git-installable",
+      "version": "git+https://github.com/OpenMined/syft.js.git#75cce98b239ec21eca557639e0d94f5c11580df1",
+      "from": "git+https://github.com/OpenMined/syft.js.git",
       "requires": {
         "@tensorflow/tfjs": "^1.5.1",
         "long": "^4.0.0",
@@ -2429,9 +2429,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+      "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
     },
     "@types/node-fetch": {
       "version": "2.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,14 +2245,68 @@
       }
     },
     "@openmined/syft.js": {
-      "version": "0.0.1-0",
-      "resolved": "https://registry.npmjs.org/@openmined/syft.js/-/syft.js-0.0.1-0.tgz",
-      "integrity": "sha512-McWXtM1yAvLWtaXBkCcbP1sJjXa9CkzhvD4jh4cJTGXrGEiNSKo94SpKpn/QNb1b5BfURibTDaus/SB9cs47lQ==",
+      "version": "https://registry.npmjs.org/@vova/syft.js/-/syft.js-0.0.1-pb.tgz",
+      "integrity": "sha512-LgAVGU9qd7VWse7Pk7tawTJMEf5xO6njmvkNbBad6+WNhVGBlMY7Zml361An/V115O4GolN3V+4sxgvr+q3WnA==",
       "requires": {
         "@tensorflow/tfjs": "^1.5.1",
-        "pysyft-proto": "git+https://github.com/OpenMined/proto.git",
+        "long": "^4.0.0",
+        "syft-proto": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
         "tuple-w": "^1.1.1"
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@tensorflow/tfjs": {
       "version": "1.5.1",
@@ -2363,6 +2417,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2370,9 +2429,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
-      "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ=="
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/node-fetch": {
       "version": "2.5.4",
@@ -6719,6 +6778,11 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8055,6 +8119,33 @@
         "sisteransi": "^1.0.3"
       }
     },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+        }
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -8088,10 +8179,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "pysyft-proto": {
-      "version": "git+https://github.com/OpenMined/proto.git#1b62d5a88ff308d2034216babaee595060d0490b",
-      "from": "git+https://github.com/OpenMined/proto.git"
     },
     "qs": {
       "version": "6.5.2",
@@ -9086,6 +9173,13 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "syft-proto": {
+      "version": "git+https://github.com/OpenMined/syft-proto.git#0cae6d31b5277205a821a26e2492d632aeb0d311",
+      "from": "git+https://github.com/OpenMined/syft-proto.git#vvm/protocol-js-stubs",
+      "requires": {
+        "protobufjs": "~6.8.8"
       }
     },
     "symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",
-    "@openmined/syft.js": "git+https://github.com/OpenMined/syft.js.git#vvm/git-installable",
+    "@openmined/syft.js": "git+https://github.com/OpenMined/syft.js.git",
     "bcrypt": "^3.0.7",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",
-    "@openmined/syft.js": "0.0.1-0",
+    "@openmined/syft.js": "https://registry.npmjs.org/@vova/syft.js/-/syft.js-0.0.1-pb.tgz",
     "bcrypt": "^3.0.7",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",
-    "@openmined/syft.js": "https://registry.npmjs.org/@vova/syft.js/-/syft.js-0.0.1-pb.tgz",
+    "@openmined/syft.js": "git+https://github.com/OpenMined/syft.js.git#vvm/git-installable",
     "bcrypt": "^3.0.7",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.4.1",
@@ -46,7 +46,6 @@
     "@babel/node": "^7.7.7",
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.7.7",
-    "babel-core": "^6.26.3",
     "husky": "^3.1.0",
     "jest": "^24.9.0",
     "mock-socket": "^9.0.2",

--- a/seed/data.json
+++ b/seed/data.json
@@ -9,5 +9,10 @@
     "protocol": "(24, (28906269612, None, None, (1, ((6, ((5, (b'worker1',)), 52050972813)), (6, ((5, (b'worker2',)), 18433383507)))), False))",
     "jason": "(21, (52050972813, (23, ((1, ((33, ((6, ((5, (b'__add__',)), (25, (96705932678, 97860579965, (5, (b'me',)), None, (11, (1,)), True)), (6, ((25, (38061622915, 16356421672, (5, (b'me',)), None, (11, (2,)), False)),)), (0, ()))), (6, (15141345372,)))), (33, ((6, ((5, (b'torch.abs',)), None, (6, ((25, (20101591978, 15141345372, (5, (b'me',)), None, None, True)),)), (0, ()))), (6, (34896159436,)))))), (6, (97860579965,)), (6, (34896159436,)), None)), (22, ((1, (16356421672,)), (1, ((14, (16356421672, (6, ((6, (2,)), (5, (b'float32',)), (1, (4.199999809265137, 7.300000190734863)))), None, None, None, None, (5, (b'all',)))),)))), True, True, (1, ((11, (1,)),)), None, (5, (b'jasonPlan',)), None, None, (1, ())))",
     "andy": "(21, (18433383507, (23, ((1, ((33, ((6, ((5, (b'__add__',)), (25, (99282307344, 60760508877, (5, (b'me',)), None, (11, (1,)), True)), (6, ((25, (99282307344, 60760508877, (5, (b'me',)), None, (11, (1,)), True)),)), (0, ()))), (6, (87355607149,)))), (33, ((6, ((5, (b'torch.abs',)), None, (6, ((25, (42164278989, 87355607149, (5, (b'me',)), None, None, True)),)), (0, ()))), (6, (60757888340,)))))), (6, (60760508877,)), (6, (60757888340,)), None)), (22, ((1, ()), (1, ()))), False, True, (1, ((11, (1,)),)), None, (5, (b'andyPlan',)), None, None, (1, ())))"
+  },
+  "protobuf-protocol": {
+    "protocol": "CgYI3LvduywqFAoHCMnprrvCAhIJEgd3b3JrZXIxKhQKBwjDiOjk9QESCRIHd29ya2VyMg==",
+    "plan1": "CjcKBwjJ6a67wgISKgoECgICAxIHZmxvYXQzMrIBGAAAgD8AAABAAABAQAAAgEAAAKBAMzPDQEAE",
+    "plan2": "CjcKBwjDiOjk9QESKgoECgICAxIHZmxvYXQzMrIBGAAAgD8AAABAAABAQAAAgEAAAKBAMzPDQEAE"
   }
 }

--- a/seed/samples.js
+++ b/seed/samples.js
@@ -1,4 +1,9 @@
-const { detail } = require('@openmined/syft.js');
+const {
+  detail,
+  unserialize,
+  ObjectMessage,
+  protobuf
+} = require('@openmined/syft.js');
 const uuid = require('uuid/v4');
 const bcrypt = require('bcrypt');
 
@@ -19,6 +24,19 @@ const detailToObject = text => {
   };
 };
 
+const protobufToObject = (bin, obj) => {
+  const detailedObject = unserialize(null, bin, obj);
+
+  return {
+    id:
+      detailedObject instanceof ObjectMessage
+        ? detailedObject.contents.id.toString()
+        : detailedObject.id.toString(),
+    contents: bin,
+    createdBy: adminUserId
+  };
+};
+
 const protocol1 = data['three-way'].protocol;
 const bobPlan = data['three-way'].bob;
 const theoPlan = data['three-way'].theo;
@@ -28,14 +46,25 @@ const protocol2 = data['two-way'].protocol;
 const jasonPlan = data['two-way'].jason;
 const andyPlan = data['two-way'].andy;
 
-const exampleProtocols = [detailToObject(protocol1), detailToObject(protocol2)];
+const protocol3 = data['protobuf-protocol'].protocol;
+const pbPlan1 = data['protobuf-protocol'].plan1;
+const pbPlan2 = data['protobuf-protocol'].plan2;
+
+const exampleProtocols = [
+  detailToObject(protocol1),
+  detailToObject(protocol2),
+  protobufToObject(protocol3, protobuf.syft_proto.messaging.v1.Protocol)
+];
 
 const examplePlans = [
   detailToObject(bobPlan),
   detailToObject(theoPlan),
   detailToObject(alicePlan),
   detailToObject(jasonPlan),
-  detailToObject(andyPlan)
+  detailToObject(andyPlan),
+  // NOTE: these are not Plans temporarily; Plan can't be serialized yet
+  protobufToObject(pbPlan1, protobuf.syft_proto.messaging.v1.ObjectMessage),
+  protobufToObject(pbPlan2, protobuf.syft_proto.messaging.v1.ObjectMessage)
 ];
 
 const exampleUsers = [

--- a/src/protocols.js
+++ b/src/protocols.js
@@ -1,6 +1,5 @@
-import { detail } from '@openmined/syft.js';
+import { detail, unserialize, protobuf } from '@openmined/syft.js';
 import { shortenId as s } from './_helpers';
-
 const uuid = require('uuid/v4');
 
 // Get the protocol the worker is requesting
@@ -21,7 +20,17 @@ export const getProtocol = async (
   else logger.log(`Found protocol ${protocolId}`);
 
   // We also need to detail the retrieved protocol to read the plan we will need to fetch later
-  const detailedProtocol = detail(protocol.contents);
+  let detailedProtocol;
+  try {
+    detailedProtocol = detail(protocol.contents);
+  } catch (e) {
+    // fallback to protobuf
+    detailedProtocol = unserialize(
+      null,
+      protocol.contents,
+      protobuf.syft_proto.messaging.v1.Protocol
+    );
+  }
 
   // If we don't have a scopeId, we must be creating a new one
   if (!scopeId) {

--- a/test/protocols.test.js
+++ b/test/protocols.test.js
@@ -106,4 +106,33 @@ describe('Protocol', () => {
     expect(getProtocolData.plan).toBe(examplePlans[1].contents);
     expect(Object.keys(getProtocolData.participants).length).toBe(2);
   });
+
+  test('should work with protobuf-serialized protocol', async () => {
+    const creatorProtocolData = await getProtocol(
+      db,
+      {
+        workerId: uuid(),
+        protocolId: exampleProtocols[2].id
+      },
+      logger
+    );
+    const getProtocolData = await getProtocol(
+      db,
+      {
+        workerId: Object.keys(creatorProtocolData.participants)[0],
+        protocolId: exampleProtocols[2].id,
+        scopeId: creatorProtocolData.worker.scopeId
+      },
+      logger
+    );
+
+    expect(creatorProtocolData.worker.scopeId).not.toBe(null);
+    expect(Object.keys(creatorProtocolData.participants).length).toBe(1);
+    expect(creatorProtocolData.plan).toBe(examplePlans[5].contents);
+    expect(getProtocolData.worker.scopeId).toBe(
+      creatorProtocolData.worker.scopeId
+    );
+    expect(getProtocolData.plan).toBe(examplePlans[6].contents);
+    expect(Object.keys(getProtocolData.participants).length).toBe(1);
+  });
 });


### PR DESCRIPTION
This PR contains initial implementation of protobuf in grid.js as a PoC.
3rd Protocol in sample data is serialized with protobuf.
That sample Protocol (ID: 11936423388) can be retrieved with updated syft.js: https://github.com/OpenMined/syft.js/pull/74
(There're no real Plans, so it won't be executed, but you can see in console that Protocol and Tensor are loaded in browser).

NOTE: package.json is using syft.js from https://github.com/OpenMined/syft.js/pull/74 which is not yet merged & published, to pass unit tests; this needs to be changed before merge.
